### PR TITLE
Updated Combine_data.R to include -1:0 matches

### DIFF
--- a/Scripts/Combine_data.R
+++ b/Scripts/Combine_data.R
@@ -47,7 +47,7 @@ forfeit_exceptions = c('USAR2023NATIONALS')
 
 dat = bind_rows(tg) %>%
   mutate_at(vars(tourney:T2P2), toupper) %>%
-  filter(tourney %in% forfeit_exceptions | !((t1score %in% c(-1, -2) & t2score == 0) | (t2score %in% c(-1, -2) & t1score == 0)))
+  filter(tourney %in% forfeit_exceptions | !((t1score == -2 & t2score == 0) | (t2score == -2 & t1score == 0)))
 
 
 # Filtering to valid tourney and division, applying name corrections, and adding a dummy "END OF SEASON" tournament


### PR DESCRIPTION
One line change to include these -1:0 matches in the ELO model, still removes the -2:0 matches in case of injury